### PR TITLE
feat: Phase 5 - Configuration Modules

### DIFF
--- a/src/modules/groups.rs
+++ b/src/modules/groups.rs
@@ -1,0 +1,76 @@
+//! Group creation and configuration module
+
+use crate::CloudInitError;
+use crate::config::GroupConfig;
+use tracing::{debug, info};
+
+/// Create groups from cloud-config
+pub async fn create_groups(groups: &[GroupConfig]) -> Result<(), CloudInitError> {
+    for group in groups {
+        match group {
+            GroupConfig::Name(name) => {
+                create_group_simple(name).await?;
+            }
+            GroupConfig::WithMembers { name, members } => {
+                create_group_with_members(name, members).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Create a simple group
+async fn create_group_simple(name: &str) -> Result<(), CloudInitError> {
+    info!("Creating group: {}", name);
+
+    let output = tokio::process::Command::new("groupadd")
+        .arg(name)
+        .output()
+        .await
+        .map_err(|e| CloudInitError::Command(e.to_string()))?;
+
+    // Exit code 9 means group already exists, which is fine
+    if !output.status.success() && output.status.code() != Some(9) {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(CloudInitError::UserGroup(format!(
+            "Failed to create group {}: {}",
+            name, stderr
+        )));
+    }
+
+    Ok(())
+}
+
+/// Create a group and add members to it
+async fn create_group_with_members(name: &str, members: &[String]) -> Result<(), CloudInitError> {
+    // First create the group
+    create_group_simple(name).await?;
+
+    // Then add each member
+    for member in members {
+        add_user_to_group(member, name).await?;
+    }
+
+    Ok(())
+}
+
+/// Add a user to a group
+async fn add_user_to_group(username: &str, group: &str) -> Result<(), CloudInitError> {
+    debug!("Adding user {} to group {}", username, group);
+
+    let output = tokio::process::Command::new("usermod")
+        .args(["--append", "--groups", group, username])
+        .output()
+        .await
+        .map_err(|e| CloudInitError::Command(e.to_string()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(CloudInitError::UserGroup(format!(
+            "Failed to add user {} to group {}: {}",
+            username, group, stderr
+        )));
+    }
+
+    Ok(())
+}

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -1,18 +1,24 @@
 //! Hostname configuration module
 
 use crate::CloudInitError;
-use tracing::debug;
+use tokio::fs;
+use tracing::{debug, info};
 
 /// Set the system hostname
 pub async fn set_hostname(hostname: &str) -> Result<(), CloudInitError> {
-    debug!("Setting hostname to: {}", hostname);
+    info!("Setting hostname to: {}", hostname);
 
     // Write to /etc/hostname
-    tokio::fs::write("/etc/hostname", format!("{}\n", hostname))
+    fs::write("/etc/hostname", format!("{}\n", hostname))
         .await
         .map_err(CloudInitError::Io)?;
 
-    // Call hostname command to set it immediately
+    // Try hostnamectl first (systemd)
+    if try_hostnamectl(hostname).await? {
+        return Ok(());
+    }
+
+    // Fallback: hostname command
     let output = tokio::process::Command::new("hostname")
         .arg(hostname)
         .output()
@@ -27,5 +33,130 @@ pub async fn set_hostname(hostname: &str) -> Result<(), CloudInitError> {
         )));
     }
 
+    Ok(())
+}
+
+/// Set hostname with FQDN support
+pub async fn set_hostname_fqdn(
+    hostname: &str,
+    fqdn: Option<&str>,
+    manage_etc_hosts: bool,
+) -> Result<(), CloudInitError> {
+    // Set the short hostname
+    set_hostname(hostname).await?;
+
+    // If we have an FQDN and should manage /etc/hosts
+    if manage_etc_hosts {
+        let fqdn = fqdn.unwrap_or(hostname);
+        update_etc_hosts(hostname, fqdn).await?;
+    }
+
+    Ok(())
+}
+
+/// Try to set hostname via hostnamectl (systemd)
+async fn try_hostnamectl(hostname: &str) -> Result<bool, CloudInitError> {
+    debug!("Attempting to set hostname via hostnamectl");
+
+    let output = tokio::process::Command::new("hostnamectl")
+        .args(["set-hostname", hostname])
+        .output()
+        .await;
+
+    match output {
+        Ok(output) if output.status.success() => {
+            info!("Hostname set via hostnamectl");
+            Ok(true)
+        }
+        Ok(output) => {
+            debug!(
+                "hostnamectl failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            Ok(false)
+        }
+        Err(e) => {
+            debug!("hostnamectl not available: {}", e);
+            Ok(false)
+        }
+    }
+}
+
+/// Update /etc/hosts with hostname entries
+pub async fn update_etc_hosts(hostname: &str, fqdn: &str) -> Result<(), CloudInitError> {
+    debug!(
+        "Updating /etc/hosts for hostname: {}, fqdn: {}",
+        hostname, fqdn
+    );
+
+    let hosts_path = "/etc/hosts";
+
+    // Read existing hosts file
+    let existing = fs::read_to_string(hosts_path)
+        .await
+        .unwrap_or_else(|_| String::new());
+
+    // Build new hosts file
+    let mut new_lines: Vec<String> = Vec::new();
+    let mut found_127_0_0_1 = false;
+    let mut found_127_0_1_1 = false;
+
+    for line in existing.lines() {
+        let trimmed = line.trim();
+
+        // Skip empty lines and comments for now, we'll add them back
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            new_lines.push(line.to_string());
+            continue;
+        }
+
+        // Parse the line to get IP and hostnames
+        let parts: Vec<&str> = trimmed.split_whitespace().collect();
+        if parts.is_empty() {
+            new_lines.push(line.to_string());
+            continue;
+        }
+
+        let ip = parts[0];
+
+        if ip == "127.0.0.1" {
+            // Keep localhost entries, add our hostname
+            found_127_0_0_1 = true;
+            new_lines.push(format!("127.0.0.1 localhost {}", hostname));
+        } else if ip == "127.0.1.1" {
+            // This is traditionally used for the FQDN
+            found_127_0_1_1 = true;
+            if fqdn != hostname {
+                new_lines.push(format!("127.0.1.1 {} {}", fqdn, hostname));
+            } else {
+                new_lines.push(format!("127.0.1.1 {}", hostname));
+            }
+        } else {
+            // Keep other entries as-is
+            new_lines.push(line.to_string());
+        }
+    }
+
+    // Add missing entries
+    if !found_127_0_0_1 {
+        new_lines.insert(0, format!("127.0.0.1 localhost {}", hostname));
+    }
+    if !found_127_0_1_1 && fqdn != hostname {
+        // Find position after 127.0.0.1 line
+        let pos = new_lines
+            .iter()
+            .position(|l| l.starts_with("127.0.0.1"))
+            .map(|p| p + 1)
+            .unwrap_or(0);
+        new_lines.insert(pos, format!("127.0.1.1 {} {}", fqdn, hostname));
+    }
+
+    // Write back
+    let content = new_lines.join("\n") + "\n";
+    fs::write(hosts_path, &content)
+        .await
+        .map_err(CloudInitError::Io)?;
+
+    info!("Updated /etc/hosts");
     Ok(())
 }

--- a/src/modules/locale.rs
+++ b/src/modules/locale.rs
@@ -1,0 +1,114 @@
+//! Locale configuration module
+
+use crate::CloudInitError;
+use std::path::Path;
+use tokio::fs;
+use tracing::{debug, info};
+
+/// Set the system locale
+pub async fn set_locale(locale: &str) -> Result<(), CloudInitError> {
+    info!("Setting locale to: {}", locale);
+
+    // Try localectl first (systemd systems)
+    if try_localectl(locale).await? {
+        return Ok(());
+    }
+
+    // Fallback: write to config files directly
+    write_locale_conf(locale).await?;
+    write_default_locale(locale).await?;
+
+    Ok(())
+}
+
+/// Try to set locale via localectl
+async fn try_localectl(locale: &str) -> Result<bool, CloudInitError> {
+    debug!("Attempting to set locale via localectl");
+
+    let output = tokio::process::Command::new("localectl")
+        .args(["set-locale", &format!("LANG={}", locale)])
+        .output()
+        .await;
+
+    match output {
+        Ok(output) if output.status.success() => {
+            info!("Locale set via localectl");
+            Ok(true)
+        }
+        Ok(output) => {
+            debug!(
+                "localectl failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            Ok(false)
+        }
+        Err(e) => {
+            debug!("localectl not available: {}", e);
+            Ok(false)
+        }
+    }
+}
+
+/// Write /etc/locale.conf (systemd/RHEL style)
+async fn write_locale_conf(locale: &str) -> Result<(), CloudInitError> {
+    let locale_conf = Path::new("/etc/locale.conf");
+
+    let content = format!("LANG={}\n", locale);
+    fs::write(locale_conf, &content)
+        .await
+        .map_err(CloudInitError::Io)?;
+
+    debug!("Wrote /etc/locale.conf");
+    Ok(())
+}
+
+/// Write /etc/default/locale (Debian/Ubuntu style)
+async fn write_default_locale(locale: &str) -> Result<(), CloudInitError> {
+    let default_locale = Path::new("/etc/default/locale");
+
+    // Create parent directory if needed
+    if let Some(parent) = default_locale.parent()
+        && !parent.exists()
+    {
+        fs::create_dir_all(parent)
+            .await
+            .map_err(CloudInitError::Io)?;
+    }
+
+    let content = format!("LANG={}\n", locale);
+    fs::write(default_locale, &content)
+        .await
+        .map_err(CloudInitError::Io)?;
+
+    debug!("Wrote /etc/default/locale");
+    Ok(())
+}
+
+/// Generate locale if needed (Debian/Ubuntu)
+pub async fn generate_locale(locale: &str) -> Result<(), CloudInitError> {
+    debug!("Attempting to generate locale: {}", locale);
+
+    // Check if locale-gen exists
+    let output = tokio::process::Command::new("locale-gen")
+        .arg(locale)
+        .output()
+        .await;
+
+    match output {
+        Ok(output) if output.status.success() => {
+            info!("Generated locale: {}", locale);
+            Ok(())
+        }
+        Ok(output) => {
+            debug!(
+                "locale-gen failed (may be expected): {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            Ok(())
+        }
+        Err(e) => {
+            debug!("locale-gen not available: {}", e);
+            Ok(())
+        }
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -3,9 +3,12 @@
 //! Each module handles a specific aspect of cloud-init configuration.
 //! Modules are executed in a defined order during the config and final stages.
 
+pub mod groups;
 pub mod hostname;
+pub mod locale;
 pub mod runcmd;
 pub mod ssh_keys;
+pub mod timezone;
 pub mod users;
 pub mod write_files;
 

--- a/src/modules/timezone.rs
+++ b/src/modules/timezone.rs
@@ -1,0 +1,99 @@
+//! Timezone configuration module
+
+use crate::CloudInitError;
+use std::path::Path;
+use tokio::fs;
+use tracing::{debug, info};
+
+/// Set the system timezone
+pub async fn set_timezone(timezone: &str) -> Result<(), CloudInitError> {
+    info!("Setting timezone to: {}", timezone);
+
+    // Validate timezone exists
+    let zoneinfo_path = format!("/usr/share/zoneinfo/{}", timezone);
+    if !Path::new(&zoneinfo_path).exists() {
+        return Err(CloudInitError::InvalidData(format!(
+            "Invalid timezone: {} (not found in /usr/share/zoneinfo)",
+            timezone
+        )));
+    }
+
+    // Try timedatectl first (systemd systems)
+    if try_timedatectl(timezone).await? {
+        return Ok(());
+    }
+
+    // Fallback: symlink /etc/localtime
+    set_localtime_symlink(timezone).await?;
+
+    // Also write /etc/timezone for Debian-based systems
+    write_etc_timezone(timezone).await?;
+
+    Ok(())
+}
+
+/// Try to set timezone via timedatectl
+async fn try_timedatectl(timezone: &str) -> Result<bool, CloudInitError> {
+    debug!("Attempting to set timezone via timedatectl");
+
+    let output = tokio::process::Command::new("timedatectl")
+        .args(["set-timezone", timezone])
+        .output()
+        .await;
+
+    match output {
+        Ok(output) if output.status.success() => {
+            info!("Timezone set via timedatectl");
+            Ok(true)
+        }
+        Ok(output) => {
+            debug!(
+                "timedatectl failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            Ok(false)
+        }
+        Err(e) => {
+            debug!("timedatectl not available: {}", e);
+            Ok(false)
+        }
+    }
+}
+
+/// Set /etc/localtime symlink
+async fn set_localtime_symlink(timezone: &str) -> Result<(), CloudInitError> {
+    debug!("Setting /etc/localtime symlink");
+
+    let localtime = Path::new("/etc/localtime");
+    let zoneinfo = format!("/usr/share/zoneinfo/{}", timezone);
+
+    // Remove existing localtime if it exists
+    if localtime.exists() {
+        fs::remove_file(localtime)
+            .await
+            .map_err(CloudInitError::Io)?;
+    }
+
+    // Create symlink
+    #[cfg(unix)]
+    {
+        tokio::fs::symlink(&zoneinfo, localtime)
+            .await
+            .map_err(CloudInitError::Io)?;
+    }
+
+    info!("Created /etc/localtime symlink to {}", zoneinfo);
+    Ok(())
+}
+
+/// Write /etc/timezone file (Debian/Ubuntu)
+async fn write_etc_timezone(timezone: &str) -> Result<(), CloudInitError> {
+    let etc_timezone = Path::new("/etc/timezone");
+
+    fs::write(etc_timezone, format!("{}\n", timezone))
+        .await
+        .map_err(CloudInitError::Io)?;
+
+    debug!("Wrote /etc/timezone");
+    Ok(())
+}

--- a/src/modules/users.rs
+++ b/src/modules/users.rs
@@ -2,13 +2,20 @@
 
 use crate::CloudInitError;
 use crate::config::{UserConfig, UserFullConfig};
-use tracing::{debug, info};
+use std::path::Path;
+use tokio::fs;
+use tracing::{debug, info, warn};
 
 /// Create users from cloud-config
 pub async fn create_users(users: &[UserConfig]) -> Result<(), CloudInitError> {
     for user in users {
         match user {
             UserConfig::Name(name) => {
+                // Handle special "default" user
+                if name == "default" {
+                    debug!("Skipping 'default' user (would use distro default)");
+                    continue;
+                }
                 create_user_simple(name).await?;
             }
             UserConfig::Full(config) => {
@@ -62,6 +69,10 @@ async fn create_user_full(config: &UserFullConfig) -> Result<(), CloudInitError>
         cmd.args(["--uid", &uid.to_string()]);
     }
 
+    if let Some(primary_group) = &config.primary_group {
+        cmd.args(["--gid", primary_group]);
+    }
+
     if config.system == Some(true) {
         cmd.arg("--system");
     }
@@ -84,21 +95,22 @@ async fn create_user_full(config: &UserFullConfig) -> Result<(), CloudInitError>
 
     // Add to supplementary groups
     if !config.groups.is_empty() {
-        debug!("Adding user {} to groups: {:?}", config.name, config.groups);
-        let groups = config.groups.join(",");
-        let output = tokio::process::Command::new("usermod")
-            .args(["--append", "--groups", &groups, &config.name])
-            .output()
-            .await
-            .map_err(|e| CloudInitError::Command(e.to_string()))?;
+        add_user_to_groups(&config.name, &config.groups).await?;
+    }
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(CloudInitError::UserGroup(format!(
-                "Failed to add user {} to groups: {}",
-                config.name, stderr
-            )));
-        }
+    // Set password if provided
+    if let Some(passwd) = &config.passwd {
+        set_user_password(&config.name, passwd).await?;
+    }
+
+    // Lock password if requested
+    if config.lock_passwd == Some(true) {
+        lock_user_password(&config.name).await?;
+    }
+
+    // Configure sudo access
+    if let Some(sudo) = &config.sudo {
+        configure_sudo(&config.name, sudo).await?;
     }
 
     // Configure SSH keys
@@ -110,5 +122,141 @@ async fn create_user_full(config: &UserFullConfig) -> Result<(), CloudInitError>
         .await?;
     }
 
+    Ok(())
+}
+
+/// Add user to supplementary groups
+async fn add_user_to_groups(username: &str, groups: &[String]) -> Result<(), CloudInitError> {
+    debug!("Adding user {} to groups: {:?}", username, groups);
+    let groups_str = groups.join(",");
+    let output = tokio::process::Command::new("usermod")
+        .args(["--append", "--groups", &groups_str, username])
+        .output()
+        .await
+        .map_err(|e| CloudInitError::Command(e.to_string()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(CloudInitError::UserGroup(format!(
+            "Failed to add user {} to groups: {}",
+            username, stderr
+        )));
+    }
+    Ok(())
+}
+
+/// Set user password (expects pre-hashed password)
+async fn set_user_password(username: &str, hashed_password: &str) -> Result<(), CloudInitError> {
+    debug!("Setting password for user {}", username);
+
+    // Use chpasswd with -e for pre-encrypted passwords
+    let input = format!("{}:{}", username, hashed_password);
+    let mut child = tokio::process::Command::new("chpasswd")
+        .arg("-e")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| CloudInitError::Command(e.to_string()))?;
+
+    if let Some(stdin) = child.stdin.as_mut() {
+        use tokio::io::AsyncWriteExt;
+        stdin
+            .write_all(input.as_bytes())
+            .await
+            .map_err(|e| CloudInitError::Command(e.to_string()))?;
+    }
+
+    let output = child
+        .wait_with_output()
+        .await
+        .map_err(|e| CloudInitError::Command(e.to_string()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(CloudInitError::UserGroup(format!(
+            "Failed to set password for {}: {}",
+            username, stderr
+        )));
+    }
+
+    Ok(())
+}
+
+/// Lock user password (disable password login)
+async fn lock_user_password(username: &str) -> Result<(), CloudInitError> {
+    debug!("Locking password for user {}", username);
+
+    let output = tokio::process::Command::new("passwd")
+        .args(["-l", username])
+        .output()
+        .await
+        .map_err(|e| CloudInitError::Command(e.to_string()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        warn!("Failed to lock password for {}: {}", username, stderr);
+        // Don't fail - user may not have a password set
+    }
+
+    Ok(())
+}
+
+/// Configure sudo access for a user
+async fn configure_sudo(username: &str, sudo_spec: &str) -> Result<(), CloudInitError> {
+    debug!("Configuring sudo for user {}: {}", username, sudo_spec);
+
+    // Create sudoers.d directory if it doesn't exist
+    let sudoers_dir = Path::new("/etc/sudoers.d");
+    if !sudoers_dir.exists() {
+        fs::create_dir_all(sudoers_dir)
+            .await
+            .map_err(CloudInitError::Io)?;
+    }
+
+    // Write sudoers file for this user
+    // Filename is 90-cloud-init-users to match Python cloud-init
+    let sudoers_file = sudoers_dir.join(format!("90-cloud-init-{}", username));
+
+    // Format: "username sudo_spec" or if sudo_spec contains username, use as-is
+    let content = if sudo_spec.contains(username) || sudo_spec.starts_with("ALL") {
+        // sudo_spec is complete (e.g., "ALL=(ALL) NOPASSWD:ALL")
+        format!("{} {}\n", username, sudo_spec)
+    } else {
+        // sudo_spec is just the rule
+        format!("{} {}\n", username, sudo_spec)
+    };
+
+    fs::write(&sudoers_file, &content)
+        .await
+        .map_err(CloudInitError::Io)?;
+
+    // Set permissions to 0440 (required for sudoers files)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&sudoers_file, std::fs::Permissions::from_mode(0o440))
+            .await
+            .map_err(CloudInitError::Io)?;
+    }
+
+    // Validate sudoers file
+    let output = tokio::process::Command::new("visudo")
+        .args(["-c", "-f", &sudoers_file.to_string_lossy()])
+        .output()
+        .await
+        .map_err(|e| CloudInitError::Command(e.to_string()))?;
+
+    if !output.status.success() {
+        // Remove invalid sudoers file
+        let _ = fs::remove_file(&sudoers_file).await;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(CloudInitError::UserGroup(format!(
+            "Invalid sudoers configuration for {}: {}",
+            username, stderr
+        )));
+    }
+
+    info!("Configured sudo access for user {}", username);
     Ok(())
 }

--- a/src/modules/write_files.rs
+++ b/src/modules/write_files.rs
@@ -3,6 +3,8 @@
 use crate::CloudInitError;
 use crate::config::WriteFileConfig;
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use flate2::read::GzDecoder;
+use std::io::Read;
 use std::path::Path;
 use tokio::fs;
 use tracing::{debug, info};
@@ -10,7 +12,22 @@ use tracing::{debug, info};
 /// Write files from cloud-config
 pub async fn write_files(files: &[WriteFileConfig]) -> Result<(), CloudInitError> {
     for file in files {
+        // Skip deferred files - they'll be written later
+        if file.defer == Some(true) {
+            debug!("Deferring write of: {}", file.path);
+            continue;
+        }
         write_file(file).await?;
+    }
+    Ok(())
+}
+
+/// Write deferred files (called in final stage)
+pub async fn write_deferred_files(files: &[WriteFileConfig]) -> Result<(), CloudInitError> {
+    for file in files {
+        if file.defer == Some(true) {
+            write_file(file).await?;
+        }
     }
     Ok(())
 }
@@ -27,23 +44,8 @@ async fn write_file(config: &WriteFileConfig) -> Result<(), CloudInitError> {
             .map_err(CloudInitError::Io)?;
     }
 
-    // Decode content if needed
-    let content = match config.encoding.as_deref() {
-        Some("base64") | Some("b64") => {
-            let decoded = BASE64
-                .decode(&config.content)
-                .map_err(|e| CloudInitError::InvalidData(format!("Invalid base64: {}", e)))?;
-            String::from_utf8(decoded)
-                .map_err(|e| CloudInitError::InvalidData(format!("Invalid UTF-8: {}", e)))?
-        }
-        Some("gzip") | Some("gz") => {
-            // TODO: Implement gzip decompression
-            return Err(CloudInitError::InvalidData(
-                "gzip encoding not yet supported".into(),
-            ));
-        }
-        _ => config.content.clone(),
-    };
+    // Decode content based on encoding
+    let content = decode_content(&config.content, config.encoding.as_deref())?;
 
     // Write or append
     if config.append == Some(true) {
@@ -58,10 +60,9 @@ async fn write_file(config: &WriteFileConfig) -> Result<(), CloudInitError> {
             .map_err(CloudInitError::Io)?;
     }
 
-    // Set permissions
-    if let Some(perms) = &config.permissions {
-        set_permissions(path, perms).await?;
-    }
+    // Set permissions (default to 0644 if not specified)
+    let perms = config.permissions.as_deref().unwrap_or("0644");
+    set_permissions(path, perms).await?;
 
     // Set ownership
     if let Some(owner) = &config.owner {
@@ -69,6 +70,52 @@ async fn write_file(config: &WriteFileConfig) -> Result<(), CloudInitError> {
     }
 
     Ok(())
+}
+
+/// Decode content based on encoding type
+fn decode_content(content: &str, encoding: Option<&str>) -> Result<String, CloudInitError> {
+    match encoding {
+        Some("base64") | Some("b64") => {
+            let decoded = BASE64
+                .decode(content)
+                .map_err(|e| CloudInitError::InvalidData(format!("Invalid base64: {}", e)))?;
+            String::from_utf8(decoded)
+                .map_err(|e| CloudInitError::InvalidData(format!("Invalid UTF-8: {}", e)))
+        }
+        Some("gzip") | Some("gz") => {
+            // Content is raw gzip bytes (unusual but supported)
+            decompress_gzip(content.as_bytes())
+        }
+        Some("gz+base64") | Some("gzip+base64") | Some("gz+b64") => {
+            // Base64-encoded gzip data (most common)
+            let decoded = BASE64
+                .decode(content)
+                .map_err(|e| CloudInitError::InvalidData(format!("Invalid base64: {}", e)))?;
+            decompress_gzip(&decoded)
+        }
+        Some("b64+gzip") | Some("base64+gzip") => {
+            // Same as above, alternate naming
+            let decoded = BASE64
+                .decode(content)
+                .map_err(|e| CloudInitError::InvalidData(format!("Invalid base64: {}", e)))?;
+            decompress_gzip(&decoded)
+        }
+        Some(other) => Err(CloudInitError::InvalidData(format!(
+            "Unknown encoding: {}",
+            other
+        ))),
+        None => Ok(content.to_string()),
+    }
+}
+
+/// Decompress gzip data
+fn decompress_gzip(data: &[u8]) -> Result<String, CloudInitError> {
+    let mut decoder = GzDecoder::new(data);
+    let mut decompressed = String::new();
+    decoder
+        .read_to_string(&mut decompressed)
+        .map_err(|e| CloudInitError::InvalidData(format!("Failed to decompress gzip: {}", e)))?;
+    Ok(decompressed)
 }
 
 async fn set_permissions(path: &Path, perms: &str) -> Result<(), CloudInitError> {


### PR DESCRIPTION
## Summary
Implements Phase 5 high-priority configuration modules for cloud-init-rs.

## Changes

### Enhanced Modules

**Users (`users.rs`)**
- sudo configuration via `/etc/sudoers.d/90-cloud-init-{user}`
- Password setting with `chpasswd -e` (pre-hashed passwords)
- `lock_passwd` support via `passwd -l`
- `primary_group` support
- Handle `default` user placeholder

**Write Files (`write_files.rs`)**
- gzip decompression (gz, gzip+base64, b64+gzip encodings)
- Deferred file writes support (`defer: true`)
- Default permissions (0644 if not specified)

**Hostname (`hostname.rs`)**
- `hostnamectl` support for systemd systems
- FQDN handling via `set_hostname_fqdn()`
- `/etc/hosts` management with 127.0.1.1 entries

### New Modules

- **groups.rs** - Create groups via `groupadd`, add members
- **timezone.rs** - `timedatectl` with `/etc/localtime` symlink fallback
- **locale.rs** - `localectl` with `/etc/locale.conf` and `/etc/default/locale` fallback

## Testing
- All 87 tests pass
- Clippy clean
- Formatted with rustfmt

## Roadmap Progress
This completes the high-priority items in Phase 5:
- [x] Users with sudo, SSH keys, passwords
- [x] Groups creation
- [x] write_files with gzip support
- [x] hostname with FQDN and /etc/hosts
- [x] timezone module
- [x] locale module