### PR TITLE
feat: Add remaining Phase 5 modules (bootcmd, ntp, packages)

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -31,6 +31,10 @@ pub struct CloudConfig {
     #[serde(default)]
     pub write_files: Vec<WriteFileConfig>,
 
+    /// Early boot commands
+    #[serde(default)]
+    pub bootcmd: Vec<RunCmd>,
+
     /// Commands to run
     #[serde(default)]
     pub runcmd: Vec<RunCmd>,
@@ -57,6 +61,9 @@ pub struct CloudConfig {
 
     /// Locale to set
     pub locale: Option<String>,
+
+    /// NTP configuration
+    pub ntp: Option<NtpConfig>,
 
     /// Growpart configuration
     pub growpart: Option<GrowpartConfig>,
@@ -158,6 +165,20 @@ pub struct PhoneHomeConfig {
     pub url: String,
     pub post: Option<Vec<String>>,
     pub tries: Option<u32>,
+}
+
+/// NTP configuration
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct NtpConfig {
+    /// Enable NTP
+    pub enabled: Option<bool>,
+    /// NTP servers
+    #[serde(default)]
+    pub servers: Vec<String>,
+    /// NTP pools
+    #[serde(default)]
+    pub pools: Vec<String>,
 }
 
 impl CloudConfig {

--- a/src/modules/bootcmd.rs
+++ b/src/modules/bootcmd.rs
@@ -1,0 +1,68 @@
+//! Bootcmd module - execute early boot commands
+//!
+//! These commands run very early in the boot process, before most other
+//! cloud-init modules. They should be used sparingly and only when
+//! necessary for early system configuration.
+
+use crate::CloudInitError;
+use crate::config::RunCmd;
+use tracing::{debug, info, warn};
+
+/// Execute bootcmd directives (early boot commands)
+pub async fn execute_bootcmd(commands: &[RunCmd]) -> Result<(), CloudInitError> {
+    if commands.is_empty() {
+        return Ok(());
+    }
+
+    info!("Executing {} bootcmd commands", commands.len());
+
+    for (i, cmd) in commands.iter().enumerate() {
+        debug!("Executing bootcmd {}/{}", i + 1, commands.len());
+        execute_command(cmd).await?;
+    }
+
+    Ok(())
+}
+
+async fn execute_command(cmd: &RunCmd) -> Result<(), CloudInitError> {
+    let output = match cmd {
+        RunCmd::Shell(shell_cmd) => {
+            debug!("Running bootcmd shell command: {}", shell_cmd);
+            tokio::process::Command::new("sh")
+                .args(["-c", shell_cmd])
+                .output()
+                .await
+                .map_err(|e| CloudInitError::Command(e.to_string()))?
+        }
+        RunCmd::Args(args) => {
+            if args.is_empty() {
+                return Ok(());
+            }
+            debug!("Running bootcmd: {:?}", args);
+            tokio::process::Command::new(&args[0])
+                .args(&args[1..])
+                .output()
+                .await
+                .map_err(|e| CloudInitError::Command(e.to_string()))?
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        warn!(
+            "Bootcmd exited with status {}: {}",
+            output.status.code().unwrap_or(-1),
+            stderr
+        );
+        // bootcmd failures are typically non-fatal
+    }
+
+    if !output.stdout.is_empty() {
+        debug!(
+            "bootcmd stdout: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+    }
+
+    Ok(())
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -3,9 +3,12 @@
 //! Each module handles a specific aspect of cloud-init configuration.
 //! Modules are executed in a defined order during the config and final stages.
 
+pub mod bootcmd;
 pub mod groups;
 pub mod hostname;
 pub mod locale;
+pub mod ntp;
+pub mod packages;
 pub mod runcmd;
 pub mod ssh_keys;
 pub mod timezone;

--- a/src/modules/ntp.rs
+++ b/src/modules/ntp.rs
@@ -1,0 +1,207 @@
+//! NTP configuration module
+//!
+//! Configures NTP time synchronization via chrony, systemd-timesyncd, or ntpd.
+
+use crate::CloudInitError;
+use std::path::Path;
+use tokio::fs;
+use tracing::{debug, info, warn};
+
+/// NTP configuration
+#[derive(Debug, Clone)]
+pub struct NtpConfig {
+    /// NTP servers to use
+    pub servers: Vec<String>,
+    /// NTP pools to use
+    pub pools: Vec<String>,
+    /// Enable NTP (default: true)
+    pub enabled: bool,
+}
+
+impl Default for NtpConfig {
+    fn default() -> Self {
+        Self {
+            servers: Vec::new(),
+            pools: vec!["pool.ntp.org".to_string()],
+            enabled: true,
+        }
+    }
+}
+
+/// Configure NTP based on available service
+pub async fn configure_ntp(config: &NtpConfig) -> Result<(), CloudInitError> {
+    if !config.enabled {
+        info!("NTP disabled by configuration");
+        return Ok(());
+    }
+
+    info!("Configuring NTP");
+
+    // Try services in order of preference
+    if try_configure_chrony(config).await? {
+        return Ok(());
+    }
+
+    if try_configure_timesyncd(config).await? {
+        return Ok(());
+    }
+
+    if try_configure_ntpd(config).await? {
+        return Ok(());
+    }
+
+    warn!("No supported NTP service found");
+    Ok(())
+}
+
+/// Configure chrony (preferred on RHEL/Fedora/newer Ubuntu)
+async fn try_configure_chrony(config: &NtpConfig) -> Result<bool, CloudInitError> {
+    let chrony_conf = Path::new("/etc/chrony.conf");
+    let chrony_d = Path::new("/etc/chrony/chrony.conf");
+
+    let conf_path = if chrony_conf.exists() {
+        chrony_conf
+    } else if chrony_d.exists() {
+        chrony_d
+    } else {
+        debug!("Chrony not found");
+        return Ok(false);
+    };
+
+    info!("Configuring chrony");
+
+    // Build configuration
+    let mut content = String::new();
+    content.push_str("# Configured by cloud-init-rs\n");
+
+    for server in &config.servers {
+        content.push_str(&format!("server {} iburst\n", server));
+    }
+
+    for pool in &config.pools {
+        content.push_str(&format!("pool {} iburst\n", pool));
+    }
+
+    // Add common chrony options
+    content.push_str("\n# Common settings\n");
+    content.push_str("driftfile /var/lib/chrony/drift\n");
+    content.push_str("makestep 1.0 3\n");
+    content.push_str("rtcsync\n");
+
+    fs::write(conf_path, &content)
+        .await
+        .map_err(CloudInitError::Io)?;
+
+    // Restart chrony
+    restart_service("chronyd").await?;
+
+    Ok(true)
+}
+
+/// Configure systemd-timesyncd (default on many systemd systems)
+async fn try_configure_timesyncd(config: &NtpConfig) -> Result<bool, CloudInitError> {
+    let timesyncd_conf = Path::new("/etc/systemd/timesyncd.conf");
+
+    // Check if systemd-timesyncd is available
+    let status = tokio::process::Command::new("systemctl")
+        .args(["is-enabled", "systemd-timesyncd"])
+        .output()
+        .await;
+
+    if status.is_err() || !status.unwrap().status.success() {
+        debug!("systemd-timesyncd not available");
+        return Ok(false);
+    }
+
+    info!("Configuring systemd-timesyncd");
+
+    // Build configuration
+    let servers: Vec<&str> = config.servers.iter().map(|s| s.as_str()).collect();
+    let pools: Vec<&str> = config.pools.iter().map(|s| s.as_str()).collect();
+
+    let ntp_line = if !servers.is_empty() {
+        servers.join(" ")
+    } else {
+        pools.join(" ")
+    };
+
+    let content = format!("# Configured by cloud-init-rs\n[Time]\nNTP={}\n", ntp_line);
+
+    fs::write(timesyncd_conf, &content)
+        .await
+        .map_err(CloudInitError::Io)?;
+
+    // Restart timesyncd
+    restart_service("systemd-timesyncd").await?;
+
+    Ok(true)
+}
+
+/// Configure ntpd (legacy systems)
+async fn try_configure_ntpd(config: &NtpConfig) -> Result<bool, CloudInitError> {
+    let ntp_conf = Path::new("/etc/ntp.conf");
+
+    if !ntp_conf.exists() {
+        debug!("ntpd not found");
+        return Ok(false);
+    }
+
+    info!("Configuring ntpd");
+
+    // Build configuration
+    let mut content = String::new();
+    content.push_str("# Configured by cloud-init-rs\n");
+    content.push_str("driftfile /var/lib/ntp/drift\n\n");
+
+    for server in &config.servers {
+        content.push_str(&format!("server {} iburst\n", server));
+    }
+
+    for pool in &config.pools {
+        content.push_str(&format!("pool {} iburst\n", pool));
+    }
+
+    // Restrict access
+    content.push_str("\n# Access control\n");
+    content.push_str("restrict default kod nomodify notrap nopeer noquery\n");
+    content.push_str("restrict 127.0.0.1\n");
+    content.push_str("restrict ::1\n");
+
+    fs::write(ntp_conf, &content)
+        .await
+        .map_err(CloudInitError::Io)?;
+
+    // Restart ntpd
+    restart_service("ntpd").await?;
+
+    Ok(true)
+}
+
+/// Restart a systemd service
+async fn restart_service(service: &str) -> Result<(), CloudInitError> {
+    debug!("Restarting service: {}", service);
+
+    let output = tokio::process::Command::new("systemctl")
+        .args(["restart", service])
+        .output()
+        .await;
+
+    match output {
+        Ok(output) if output.status.success() => {
+            info!("Restarted {}", service);
+            Ok(())
+        }
+        Ok(output) => {
+            warn!(
+                "Failed to restart {}: {}",
+                service,
+                String::from_utf8_lossy(&output.stderr)
+            );
+            Ok(())
+        }
+        Err(e) => {
+            warn!("Could not restart {}: {}", service, e);
+            Ok(())
+        }
+    }
+}

--- a/src/modules/packages.rs
+++ b/src/modules/packages.rs
@@ -1,0 +1,180 @@
+//! Package management module
+//!
+//! Installs packages using the appropriate package manager (apt, yum, dnf, zypper).
+
+use crate::CloudInitError;
+use tracing::{debug, info, warn};
+
+/// Detected package manager
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackageManager {
+    Apt,
+    Dnf,
+    Yum,
+    Zypper,
+    Apk,
+}
+
+impl PackageManager {
+    /// Detect the system's package manager
+    pub async fn detect() -> Option<Self> {
+        // Check in order of preference
+        if command_exists("apt-get").await {
+            return Some(Self::Apt);
+        }
+        if command_exists("dnf").await {
+            return Some(Self::Dnf);
+        }
+        if command_exists("yum").await {
+            return Some(Self::Yum);
+        }
+        if command_exists("zypper").await {
+            return Some(Self::Zypper);
+        }
+        if command_exists("apk").await {
+            return Some(Self::Apk);
+        }
+        None
+    }
+
+    fn install_command(&self) -> (&str, Vec<&str>) {
+        match self {
+            Self::Apt => ("apt-get", vec!["install", "-y"]),
+            Self::Dnf => ("dnf", vec!["install", "-y"]),
+            Self::Yum => ("yum", vec!["install", "-y"]),
+            Self::Zypper => ("zypper", vec!["--non-interactive", "install"]),
+            Self::Apk => ("apk", vec!["add", "--no-cache"]),
+        }
+    }
+
+    fn update_command(&self) -> (&str, Vec<&str>) {
+        match self {
+            Self::Apt => ("apt-get", vec!["update"]),
+            Self::Dnf => ("dnf", vec!["check-update"]),
+            Self::Yum => ("yum", vec!["check-update"]),
+            Self::Zypper => ("zypper", vec!["--non-interactive", "refresh"]),
+            Self::Apk => ("apk", vec!["update"]),
+        }
+    }
+
+    fn upgrade_command(&self) -> (&str, Vec<&str>) {
+        match self {
+            Self::Apt => ("apt-get", vec!["upgrade", "-y"]),
+            Self::Dnf => ("dnf", vec!["upgrade", "-y"]),
+            Self::Yum => ("yum", vec!["update", "-y"]),
+            Self::Zypper => ("zypper", vec!["--non-interactive", "update"]),
+            Self::Apk => ("apk", vec!["upgrade"]),
+        }
+    }
+}
+
+/// Check if a command exists
+async fn command_exists(cmd: &str) -> bool {
+    tokio::process::Command::new("which")
+        .arg(cmd)
+        .output()
+        .await
+        .is_ok_and(|o| o.status.success())
+}
+
+/// Update package cache
+pub async fn update_package_cache() -> Result<(), CloudInitError> {
+    let pm = PackageManager::detect()
+        .await
+        .ok_or_else(|| CloudInitError::Module {
+            module: "packages".to_string(),
+            message: "No supported package manager found".to_string(),
+        })?;
+
+    info!("Updating package cache using {:?}", pm);
+
+    let (cmd, args) = pm.update_command();
+    let output = tokio::process::Command::new(cmd)
+        .args(&args)
+        .env("DEBIAN_FRONTEND", "noninteractive")
+        .output()
+        .await
+        .map_err(|e| CloudInitError::Command(e.to_string()))?;
+
+    // Note: yum/dnf check-update returns 100 if updates available, which is not an error
+    if !output.status.success() && output.status.code() != Some(100) {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        warn!("Package cache update had issues: {}", stderr);
+        // Don't fail - update issues are often non-fatal
+    }
+
+    Ok(())
+}
+
+/// Upgrade all packages
+pub async fn upgrade_packages() -> Result<(), CloudInitError> {
+    let pm = PackageManager::detect()
+        .await
+        .ok_or_else(|| CloudInitError::Module {
+            module: "packages".to_string(),
+            message: "No supported package manager found".to_string(),
+        })?;
+
+    info!("Upgrading packages using {:?}", pm);
+
+    let (cmd, args) = pm.upgrade_command();
+    let output = tokio::process::Command::new(cmd)
+        .args(&args)
+        .env("DEBIAN_FRONTEND", "noninteractive")
+        .output()
+        .await
+        .map_err(|e| CloudInitError::Command(e.to_string()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        warn!("Package upgrade had issues: {}", stderr);
+    }
+
+    Ok(())
+}
+
+/// Install packages
+pub async fn install_packages(packages: &[String]) -> Result<(), CloudInitError> {
+    if packages.is_empty() {
+        return Ok(());
+    }
+
+    let pm = PackageManager::detect()
+        .await
+        .ok_or_else(|| CloudInitError::Module {
+            module: "packages".to_string(),
+            message: "No supported package manager found".to_string(),
+        })?;
+
+    info!("Installing {} packages using {:?}", packages.len(), pm);
+    debug!("Packages: {:?}", packages);
+
+    let (cmd, base_args) = pm.install_command();
+    let mut args: Vec<&str> = base_args;
+    for pkg in packages {
+        args.push(pkg.as_str());
+    }
+
+    let output = tokio::process::Command::new(cmd)
+        .args(&args)
+        .env("DEBIAN_FRONTEND", "noninteractive")
+        .output()
+        .await
+        .map_err(|e| CloudInitError::Command(e.to_string()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(CloudInitError::Module {
+            module: "packages".to_string(),
+            message: format!("Failed to install packages: {}", stderr),
+        });
+    }
+
+    info!("Successfully installed {} packages", packages.len());
+    Ok(())
+}
+
+/// Install a single package
+pub async fn install_package(package: &str) -> Result<(), CloudInitError> {
+    install_packages(&[package.to_string()]).await
+}


### PR DESCRIPTION
## Summary
Implements the remaining configuration modules for Phase 5.

## New Modules

### bootcmd
Early boot commands that run before other modules. Supports the same command format as runcmd (string or array).

### ntp
NTP configuration supporting multiple backends:
- chrony (default)
- systemd-timesyncd  
- ntpd

Configures servers and pools for time synchronization.

### packages
Package installation with automatic package manager detection:
- apt (Debian/Ubuntu)
- dnf/yum (RHEL/Fedora)
- zypper (SUSE)
- apk (Alpine)

## Config Changes
- Added `bootcmd: Vec<RunCmd>` field to CloudConfig
- Added `ntp: Option<NtpConfig>` field with servers, pools, and enabled options

## Testing
All 87 tests pass. Clippy clean.